### PR TITLE
feat: Add SLURM support and new DLMC run script

### DIFF
--- a/compile_GPU_SpMM_ASpT.sh
+++ b/compile_GPU_SpMM_ASpT.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --export=ALL
+#SBATCH --job-name="compressed"
+#SBATCH --mail-type=begin
+#SBATCH --mail-type=end
+#SBATCH --nodes=1
+#SBATCH --output="compressed.%j.%N.out"
+#SBATCH -t 06:00:00
+
+module load StdEnv/2020
+module load cmake
+module load gcc
+module load python
+module load cuda/12.2
+
 cd ASpT_SpMM_GPU
-nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 sspmm_32.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o sspmm_32
-nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 sspmm_128.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o sspmm_128
-nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 dspmm_32.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o dspmm_32
-nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 dspmm_128.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o dspmm_128
+nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_53,code=sm_53 sspmm_32.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o sspmm_32
+nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_53,code=sm_53 sspmm_128.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o sspmm_128
+nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_53,code=sm_53 dspmm_32.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o dspmm_32
+nvcc -std=c++11 -O3 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_53,code=sm_53 dspmm_128.cu --use_fast_math -Xptxas "-v -dlcm=ca" -o dspmm_128
 cd ..
 

--- a/run_GPU_SpMM_dlmc.sh
+++ b/run_GPU_SpMM_dlmc.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --export=ALL
+#SBATCH --job-name="compressed_dlmc" # Changed job name slightly
+#SBATCH --mail-type=begin
+#SBATCH --mail-type=end
+#SBATCH --nodes=1
+#SBATCH --output="compressed_dlmc.%j.%N.out" # Changed output file name
+#SBATCH -t 06:00:00
+
+module load StdEnv/2020
+module load cmake
+module load gcc
+module load python
+module load cuda/12.2
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <matrix_list_file>"
+  exit 1
+fi
+MATRIX_LIST_FILE=$1
+
+mkdir -p GPU_SpMM_dlmc_result # Ensure directory exists
+
+# Initialize main output files with headers
+echo "dataset,ASpT_GFLOPs(K=4),ASpT_diff_%%(K=4),ASpT_GFLOPs(K=8),ASpT_diff_%%(K=8),ASpT_GFLOPs(K=32),ASpT_diff_%%(K=32),ASpT_GFLOPs(K=128),ASpT_diff_%%(K=128)" > SpMM_GPU_SP.out
+echo "dataset,ASpT_GFLOPs(K=4),ASpT_diff_%%(K=4),ASpT_GFLOPs(K=8),ASpT_diff_%%(K=8),ASpT_GFLOPs(K=32),ASpT_diff_%%(K=32),ASpT_GFLOPs(K=128),ASpT_diff_%%(K=128)" > SpMM_GPU_DP.out
+
+# Single Precision Loop
+while read -r mtx_file_path; do
+  if [ -z "$mtx_file_path" ]; then # Skip empty lines
+    continue
+  fi
+  matrix_name=$(basename "$mtx_file_path" .mtx)
+  echo -n "$matrix_name," >> SpMM_GPU_SP.out # Write matrix name, start of new line
+  ../ASpT_SpMM_GPU/sspmm_128 "$mtx_file_path" 4 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/sspmm_128 "$mtx_file_path" 8 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/sspmm_128 "$mtx_file_path" 32 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/sspmm_128 "$mtx_file_path" 128 # Appends GFLOPs,diff_%,
+  sed -i '$ s/,$//' SpMM_GPU_SP.out # Remove the last comma from the line just written
+  echo >> SpMM_GPU_SP.out # Add a newline to complete the line
+done < "$MATRIX_LIST_FILE"
+
+# Double Precision Loop
+while read -r mtx_file_path; do
+  if [ -z "$mtx_file_path" ]; then # Skip empty lines
+    continue
+  fi
+  matrix_name=$(basename "$mtx_file_path" .mtx)
+  echo -n "$matrix_name," >> SpMM_GPU_DP.out # Write matrix name, start of new line
+  ../ASpT_SpMM_GPU/dspmm_128 "$mtx_file_path" 4 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/dspmm_128 "$mtx_file_path" 8 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/dspmm_128 "$mtx_file_path" 32 # Appends GFLOPs,diff_%,
+  ../ASpT_SpMM_GPU/dspmm_128 "$mtx_file_path" 128 # Appends GFLOPs,diff_%,
+  sed -i '$ s/,$//' SpMM_GPU_DP.out # Remove the last comma from the line just written
+  echo >> SpMM_GPU_DP.out # Add a newline to complete the line
+done < "$MATRIX_LIST_FILE"
+
+# Finalize and Cleanup
+mv SpMM_GPU_SP.out GPU_SpMM_dlmc_result/SpMM_GPU_SP_dlmc.out
+mv SpMM_GPU_DP.out GPU_SpMM_dlmc_result/SpMM_GPU_DP_dlmc.out
+rm -f SpMM_GPU_SP_preprocessing.out SpMM_GPU_DP_preprocessing.out # Remove preprocessing files
+rm -f gmon.out


### PR DESCRIPTION
Modifies `compile_GPU_SpMM_ASpT.sh` to:
- Include SLURM batch directives and module loads.
- Add compilation targets for NVIDIA A100 (sm_80) and Jetson Nano (sm_53) in addition to the existing sm_60.

Creates `run_GPU_SpMM_dlmc.sh`:
- A new SLURM-based script to run ASpT benchmarks.
- Takes a text file listing .mtx matrix files as input.
- Runs ASpT (Single and Double Precision) for K=4, 8, 32, and 128. Uses `sspmm_128` and `dspmm_128` executables for these runs.
- Outputs results to `GPU_SpMM_dlmc_result/` in CSV format. Headers include GFLOPs and diff_% for each bitrate.
- Manages temporary output files generated by ASpT executables.